### PR TITLE
Check for existing zookeeper before downloading

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -17,11 +17,16 @@
   debug: >
    msg="Got Version {{version.stdout}}"
 
+- name: Debian | Check for existance of ZooKeeper
+  stat: path={{zookeeper_inst.inst_dir}}/zookeeper-{{version.stdout}}
+  register: is_installed
+
 - name: Debian | Download ZooKeeper
   get_url: >
    url={{zookeeper_inst.downloadURL}}
    dest={{zookeeper_inst.inst_dir}}
    mode=0440
+  when: not is_installed.stat.isdir is defined
 
 - name: Debian | Extract ZooKeeper from Download
   unarchive: >


### PR DESCRIPTION
Previously the entire archive was being downloaded
even if already installed which made ansible runs slow.

We now check if the specified version is already installed
and skip the download if so.